### PR TITLE
On equip on unequip

### DIFF
--- a/ScriptHandlers/Scripts.cs
+++ b/ScriptHandlers/Scripts.cs
@@ -20,6 +20,7 @@ namespace NWN.ScriptHandlers
      .Concat(Systems.PlayerSystem.Register)
      .Concat(Systems.ChatSystem.Register)
      .Concat(Systems.SpellSystem.Register)
+     .Concat(Systems.ItemSystem.Register)
      .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
     private static int HandleModuleLoad(uint oidSelf)
@@ -53,6 +54,11 @@ namespace NWN.ScriptHandlers
 
       NWNX.Events.SubscribeEvent("NWNX_ON_CAST_SPELL_BEFORE", "event_spellcast");
       NWNX.Events.ToggleDispatchListMode("NWNX_ON_CAST_SPELL_BEFORE", "event_spellcast", 1);
+
+      NWNX.Events.SubscribeEvent("NWNX_ON_ITEM_EQUIP_BEFORE", "event_items");
+      NWNX.Events.ToggleDispatchListMode("NWNX_ON_ITEM_EQUIP_BEFORE", "event_items", 1);
+      NWNX.Events.SubscribeEvent("NWNX_ON_ITEM_UNEQUIP_BEFORE", "event_items");
+      NWNX.Events.ToggleDispatchListMode("NWNX_ON_ITEM_UNEQUIP_BEFORE", "event_items", 1);
 
       NWNX.Events.SubscribeEvent("NWNX_ON_INPUT_ATTACK_OBJECT_BEFORE", "event_auto_spell");
       NWNX.Events.ToggleDispatchListMode("NWNX_ON_INPUT_ATTACK_OBJECT_BEFORE", "event_auto_spell", 1);

--- a/Systems/ItemSystem/ItemSystem.cs
+++ b/Systems/ItemSystem/ItemSystem.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using NWN.Enums;
+using static NWN.Systems.PlayerSystem;
+
+namespace NWN.Systems
+{
+  public static partial class ItemSystem
+  {
+    public static Dictionary<string, Func<uint, int>> Register = new Dictionary<string, Func<uint, int>>
+    {
+            { "event_items", ItemEquip },
+    };
+    private static int ItemEquip(uint oidSelf)
+    {
+      Player player;
+      if (Players.TryGetValue(oidSelf, out player))
+      {
+        string current_event = NWNX.Events.GetCurrentEvent();
+
+        if (current_event == "NWNX_ON_ITEM_EQUIP_BEFORE")
+        {
+          var oItem = NWNX.Object.StringToObject(NWNX.Events.GetEventData("ITEM"));
+          int iSlot = int.Parse(NWNX.Events.GetEventData("SLOT"));
+          NWItem oUnequip = NWScript.GetItemInSlot((InventorySlot)iSlot, player).AsItem();
+
+          if (oUnequip.IsValid && NWNX.Object.CheckFit(player, (int)oUnequip.BaseItemType) == 0)
+          {
+            player.SendMessage("Attention, votre inventaire est plein. Déséquipper cet objet risquerait de vous le faire perdre !");
+            NWNX.Events.SkipEvent();
+            return Entrypoints.SCRIPT_HANDLED;
+          }
+        }
+        else if (current_event == "NWNX_ON_ITEM_UNEQUIP_BEFORE")
+        {
+          NWItem oItem = NWNX.Object.StringToObject(NWNX.Events.GetEventData("ITEM")).AsItem();
+          if (NWNX.Object.CheckFit(player, (int)oItem.BaseItemType) == 0)
+          {
+            player.SendMessage("Attention, votre inventaire est plein. Déséquipper cet objet risquerait de vous le faire perdre !");
+            NWNX.Events.SkipEvent();
+            return Entrypoints.SCRIPT_HANDLED;
+          }
+        }
+      }
+      return Entrypoints.SCRIPT_HANDLED;
+    }
+  }
+}

--- a/Systems/PlayerSystem/PlayerSystem.cs
+++ b/Systems/PlayerSystem/PlayerSystem.cs
@@ -39,6 +39,8 @@ namespace NWN.Systems
       NWNX.Events.AddObjectToDispatchList("NWNX_ON_ADD_ASSOCIATE_AFTER", "event_summon", oPC);
       NWNX.Events.AddObjectToDispatchList("NWNX_ON_REMOVE_ASSOCIATE_AFTER", "event_summon", oPC);
       NWNX.Events.AddObjectToDispatchList("NWNX_ON_CAST_SPELL_BEFORE", "event_spellcast", oPC);
+      NWNX.Events.AddObjectToDispatchList("NWNX_ON_ITEM_EQUIP_BEFORE", "event_items", oPC);
+      NWNX.Events.AddObjectToDispatchList("NWNX_ON_ITEM_UNEQUIP_BEFORE", "event_items", oPC);
 
       //oPC.AsCreature().AddFeat(NWN.Enums.Feat.PlayerTool01);
 


### PR DESCRIPTION
Si l'inventaire du joueur ne peut contenir un item déséquipé, on annule le déséquippage et on prévient le joueur.