### PR TITLE
Cr fix dev env

### DIFF
--- a/Systems/Config.cs
+++ b/Systems/Config.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace NWN.Systems
+{
+  public static class Config
+  {
+    public enum Env
+    {
+      Dev,
+      Prod
+    }
+
+    public static Env env = InitEnv();
+
+    private static Env InitEnv ()
+    {
+      var env = Environment.GetEnvironmentVariable("ENV");
+
+      switch (env)
+      {
+        default: return Env.Prod;
+
+        case "production": return Env.Prod;
+        case "development": return Env.Dev;
+      }
+    }
+  }
+}

--- a/Systems/PlayerSystem/PlayerInit.cs
+++ b/Systems/PlayerSystem/PlayerInit.cs
@@ -115,11 +115,21 @@ namespace NWN.Systems
       WebhookSystem.StartSendingAsyncDiscordMessage($"{NWScript.GetPCPlayerName(newCharacter.oid)} vient de créer un nouveau personnage : {NWScript.GetName(newCharacter.oid)}", "AoA notification service - Nouveau personnage !");
       ObjectPlugin.SetInt(newCharacter.oid, "_STARTING_SKILL_POINTS", 5000, 1);
 
-      uint arrivalArea = NWScript.CopyArea(Module.areaDictionnary.Where(v => v.Value.tag == "entry_scene").FirstOrDefault().Value.oid);
-      Module.areaDictionnary.Add(NWScript.GetObjectUUID(arrivalArea), new Area(arrivalArea));
-      NWScript.SetName(arrivalArea, $"La galère de {NWScript.GetName(newCharacter.oid)} (Bienvenue !)");
-      NWScript.SetTag(arrivalArea, $"entry_scene_{NWScript.GetPCPublicCDKey(newCharacter.oid)}");
-      uint arrivalPoint = NWScript.GetNearestObjectByTag("ENTRY_POINT", NWScript.GetFirstObjectInArea(arrivalArea));
+      uint arrivalArea, arrivalPoint;
+
+      if (Config.env == Config.Env.Prod)
+      {
+        arrivalArea = NWScript.CopyArea(Module.areaDictionnary.Where(v => v.Value.tag == "entry_scene").FirstOrDefault().Value.oid);
+        Module.areaDictionnary.Add(NWScript.GetObjectUUID(arrivalArea), new Area(arrivalArea));
+        NWScript.SetName(arrivalArea, $"La galère de {NWScript.GetName(newCharacter.oid)} (Bienvenue !)");
+        NWScript.SetTag(arrivalArea, $"entry_scene_{NWScript.GetPCPublicCDKey(newCharacter.oid)}");
+        arrivalPoint = NWScript.GetNearestObjectByTag("ENTRY_POINT", NWScript.GetFirstObjectInArea(arrivalArea));
+
+      } else
+      {
+        arrivalArea = NWScript.GetArea(newCharacter.oid);
+        arrivalPoint = newCharacter.oid;
+      }
 
       var query = NWScript.SqlPrepareQueryCampaign(ModuleSystem.database, $"INSERT INTO playerCharacters (accountId , characterName, dateLastSaved, currentSkillJob, currentCraftJob, currentCraftObject, frostAttackOn, areaTag, position, facing) VALUES (@accountId, @name, @dateLastSaved, @currentSkillJob, @currentCraftJob, @currentCraftObject, @frostAttackOn, @areaTag, @position, @facing)");
       NWScript.SqlBindInt(query, "@accountId", newCharacter.accountId);


### PR DESCRIPTION
Ajoute une variable d'environnement "ENV" à mettre dans le fichier `start-server.sh` avec pour valeur "production" ou "development".

Cette variable permet de déterminer dans quel environnement le serveur doit tourner. Par défaut, si aucune variable n'est trouvée, le serveur choisi de s'executer en mode "production".

Corrige l'initialisation de la map de départ à la connexion d'un nouveau personnage : 
* en mode dev, pas de traitement spécial
* en mode prod, on génère la zone d'arrivée spéciale avec animation de départ
