### PR TITLE
chore(bot) : active le bot uniquement en production

### DIFF
--- a/Systems/ModuleSystem/Module.cs
+++ b/Systems/ModuleSystem/Module.cs
@@ -17,7 +17,13 @@ namespace NWN.Systems
       this.oid = oid;
       NWScript.SetLocalString(oid, "X2_S_UD_SPELLSCRIPT", "spellhook");
       this.botAsyncCommandList = new List<string>();
-      Bot.MainAsync();
+
+      if (Config.env == Config.Env.Prod)
+      {
+        // On active le bot Discord uniquement pour le serveur de production
+        Bot.MainAsync();
+      }
+
       this.CreateDatabase();
       this.SetModuleTime();
       ChatSystem.Init();


### PR DESCRIPTION
Je ne sais pas si c'est bien là qu'il faut faire ce test pour désactiver l'envoie des messages de log d'erreurs lorsqu'on test sur un module de dev au Bot discord?