### PR TITLE
Rf area destroy

### DIFF
--- a/Utils/TimingUtils.cs
+++ b/Utils/TimingUtils.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using NWN.Core;
+
+namespace NWN
+{
+  public static class TimingUtils
+  {
+    public static Action Debounce(Action action, float delay)
+    {
+      var cancelDelay = new List<bool>();
+      return () =>
+      {
+        if (cancelDelay.Count != 0)
+        {
+          cancelDelay[cancelDelay.Count - 1] = true;
+        }
+        cancelDelay.Add(false);
+        var currentIndex = cancelDelay.Count - 1;
+
+        NWScript.DelayCommand(delay, () => { 
+          if (!cancelDelay[currentIndex])
+          {
+            action();
+          }
+        });
+      };
+    }
+  }
+}


### PR DESCRIPTION
* Ajoute une fonction `DeferDestroy` qui ne détruit pas la zone s'il y a des joueurs en transition, et qui retente plus tard de détruire la zone en question
* Ajoute une fonction Debounce 